### PR TITLE
Explicitly list invalid metadata keys

### DIFF
--- a/qgis-app/plugins/tests/test_validator.py
+++ b/qgis-app/plugins/tests/test_validator.py
@@ -114,15 +114,15 @@ class TestValidatorMetadataPlugins(TestCase):
 
     @mock.patch("requests.get", side_effect=requests.exceptions.SSLError())
     def test_check_url_link_ssl_error(self, mock_request):
-        url = "http://example.com/"
-        self.assertIsNone(_check_url_link(url, "forbidden_url", "metadata attribute"))
+        urls = [{'url': "http://example.com/", 'forbidden_url': "forbidden_url", 'metadata_attr': "metadata attribute"}]
+        self.assertIsNone(_check_url_link(urls))
 
     @mock.patch("requests.get", side_effect=requests.exceptions.HTTPError())
     def test_check_url_link_does_not_exist(self, mock_request):
-        url = "http://example.com/"
+        urls = [{'url': "http://example.com/", 'forbidden_url': "forbidden_url", 'metadata_attr': "metadata attribute"}]
         self.assertRaises(
             ValidationError,
-            _check_url_link(url, "forbidden_url", "metadata attribute"),
+            _check_url_link(urls),
         )
 
 

--- a/qgis-app/plugins/validator.py
+++ b/qgis-app/plugins/validator.py
@@ -96,7 +96,7 @@ def _check_required_metadata(metadata):
             )
         )
 
-def _check_urls(urls):
+def _check_url_link(urls):
     """
     Checks if all the url link is valid.
     """
@@ -104,7 +104,7 @@ def _check_urls(urls):
         # Check against forbidden_url
         if url == forbidden_url:
             return True
-        
+
         # Check if parsed URL is valid
         try:
             parsed_url = urlparse(url)
@@ -131,7 +131,7 @@ def _check_urls(urls):
         except Exception:
             return True
         return req.status_code >= 400
-        
+
     url_error = [item for item in [url_item['metadata_attr'] for url_item in urls if error_check(url_item['url'], url_item['forbidden_url'])]]
     if len(url_error) > 0:
         url_error_str = ", ".join(url_error)
@@ -339,7 +339,7 @@ def validator(package):
         {'url': dict(metadata).get("homepage"), 'forbidden_url': "http://homepage", 'metadata_attr': "homepage"},
     ]
 
-    _check_urls(urls_to_check)
+    _check_url_link(urls_to_check)
 
 
     # Checks for LICENCE file presence


### PR DESCRIPTION
This is a proposed fix for #379

## Change summary:

- List all missing metadata keys in the upload error (1st screenshot)
- List metadata keys for invalid URL link in the upload error (2nd screenshot)
- List metadata keys for inaccessible URL link in the upload error (3rd screenshot)
- Update unit test

![list_missing_metadata](https://github.com/Xpirix/QGIS-Django/assets/43842786/4c5fd190-fabb-4c8f-b840-afef484a06f1)
![list_invalid_url](https://github.com/Xpirix/QGIS-Django/assets/43842786/e36cf805-a7b7-48b7-9fbd-313c640a1bfa)
![list_inaccessible_url](https://github.com/Xpirix/QGIS-Django/assets/43842786/0aebc6ac-1327-457a-b04f-ccee71a3513c)


## ToDo:

When this is deployed, we should update the following line to https://plugins.qgis.org/publish/ :

> The plugin metadata contains a link to the source code, an issue tracker and a license

To

> The plugin metadata contains a valid link to the `homepage`, the `repository` (source code), the `tracker` (issue tracker) and a license

